### PR TITLE
Fix/newtab defaults and navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## 1.2.0 - 2026-01-10
 - Unified default link category to a single "Links" section and improved section defaults on import.
 - Added quick-add pills, inline category add, and drag-and-drop reordering inside Customize.
-- Added blurred uploaded images mode and new gradient options; boosted dynamic favicon gradient intensity.
+- Added blurred uploaded images mode and multiple new gradients; boosted dynamic favicon gradient intensity.
 - Export filenames now include the page title and timestamp; quote imports now replace existing lines.
 - Same-tab navigation for searches and link clicks; background uploads auto-switch to images mode.
+- Added config import modes (all/quotes/search/links) and removed standalone search import.
+- Refined defaults (four starter links) and updated footer credit.
 
 ## 1.1.0 - 2026-01-04
 - Revamp with Codex focused on the Customize panel experience.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 1.2.0 - 2026-01-10
+- Unified default link category to a single "Links" section and improved section defaults on import.
+- Added quick-add pills, inline category add, and drag-and-drop reordering inside Customize.
+- Added blurred uploaded images mode and new gradient options; boosted dynamic favicon gradient intensity.
+- Export filenames now include the page title and timestamp; quote imports now replace existing lines.
+- Same-tab navigation for searches and link clicks; background uploads auto-switch to images mode.
+
+## 1.1.0 - 2026-01-04
+- Revamp with Codex focused on the Customize panel experience.
+- Expanded settings layout and navigation with branding controls.
+- Added background image previews and updated visuals/documentation.
+
+## 1.0.0 - 2023-05-08
+- Initial release.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+NOTICE
+
+Mothership on Main is authored and maintained by Dean Tammam.
+
+This project is distributed under the MIT License. The author retains ownership
+and continues to publish and evolve the project independently, including releases
+outside of any internal distribution.
+
+Any third party may host and distribute its own builds under the terms of the
+MIT License.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,23 @@
+# Privacy Policy
+
+Mothership on Main does not collect, store, sell, or transmit personal data to the author or any third party.
+
+What the extension does
+
+- Stores your configuration (links, sections, quotes, search engines, layout) in `chrome.storage.sync` so it can sync across signed-in browser profiles.
+- Stores uploaded images and favicon overrides locally in `chrome.storage.local`.
+
+Network behavior
+
+- Search queries are sent directly to the search engine you select.
+- Link clicks open the URL you configured.
+- Favicons are retrieved from the target site when available; if not, the extension may request a favicon from Google's `s2` favicon service.
+
+No telemetry
+
+- There is no analytics, telemetry, or “phone home” behavior.
+- No data is uploaded to any server controlled by the author.
+
+Open source
+
+- The full source code is available in this repository for inspection.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,12 @@
+# Testing
+
+This project is a simple, self-contained web extension, so I have not set up a formal test framework. If it continues to expand, I will likely add unit tests and functional or integration tests. For now, there is not much to integrate beyond the browser environment itself.
+
+Checklist
+
+- Load the extension as unpacked and open a new tab; confirm the page renders without errors.
+- Search: submit a query and verify it opens in the same tab.
+- Links: click a link and verify it opens in the same tab; switch to Rearrange and move links/sections, then Finish.
+- Customize: add a link, category, and search engine from the top pills; reorder links inside Customize.
+- Import/export: export config, then import it; import quotes and confirm they replace existing lines.
+- Backgrounds: switch between gradients, uploaded images, and blurred images; upload an image and confirm the dropdown switches to Uploaded images.

--- a/config.json
+++ b/config.json
@@ -22,7 +22,7 @@
     "Absolute statements can be restrictive.",
     "Being grateful is typically a positive."
   ],
-  "backgroundMode": "gradient_dynamic",
+  "backgroundMode": "gradient_signature",
   "backgrounds": [],
   "layout": {
     "maxColumns": 4,

--- a/config.json
+++ b/config.json
@@ -4,18 +4,18 @@
     "subtitle": "Your favorite bookmark replacement tool",
     "quotesTitle": "Quotes"
   },
-  "sections": ["Primary", "Secondary", "Tertiary"],
+  "sections": ["Links"],
   "links": [
-    { "section": "Primary", "name": "Gmail", "url": "https://mail.google.com/", "iconOverride": "" },
-    { "section": "Primary", "name": "Google Calendar", "url": "https://calendar.google.com/", "iconOverride": "" },
-    { "section": "Primary", "name": "Google Drive", "url": "https://drive.google.com/", "iconOverride": "" },
-    { "section": "Primary", "name": "Google Docs", "url": "https://docs.google.com/", "iconOverride": "" },
-    { "section": "Secondary", "name": "GitHub", "url": "https://github.com/", "iconOverride": "" },
-    { "section": "Secondary", "name": "Stack Overflow", "url": "https://stackoverflow.com/", "iconOverride": "" },
-    { "section": "Secondary", "name": "YouTube", "url": "https://www.youtube.com/", "iconOverride": "" },
-    { "section": "Secondary", "name": "Wikipedia", "url": "https://en.wikipedia.org/", "iconOverride": "" },
-    { "section": "Tertiary", "name": "Fireplace", "url": "https://www.youtube.com/watch?v=r2iSxZGYvCs", "iconOverride": "" },
-    { "section": "Tertiary", "name": "San Diego Pacific Beach", "url": "https://www.youtube.com/watch?v=w6P-AaGwTMM", "iconOverride": "" }
+    { "section": "Links", "name": "Gmail", "url": "https://mail.google.com/", "iconOverride": "" },
+    { "section": "Links", "name": "Google Calendar", "url": "https://calendar.google.com/", "iconOverride": "" },
+    { "section": "Links", "name": "Google Drive", "url": "https://drive.google.com/", "iconOverride": "" },
+    { "section": "Links", "name": "Google Docs", "url": "https://docs.google.com/", "iconOverride": "" },
+    { "section": "Links", "name": "GitHub", "url": "https://github.com/", "iconOverride": "" },
+    { "section": "Links", "name": "Stack Overflow", "url": "https://stackoverflow.com/", "iconOverride": "" },
+    { "section": "Links", "name": "YouTube", "url": "https://www.youtube.com/", "iconOverride": "" },
+    { "section": "Links", "name": "Wikipedia", "url": "https://en.wikipedia.org/", "iconOverride": "" },
+    { "section": "Links", "name": "Fireplace", "url": "https://www.youtube.com/watch?v=r2iSxZGYvCs", "iconOverride": "" },
+    { "section": "Links", "name": "San Diego Pacific Beach", "url": "https://www.youtube.com/watch?v=w6P-AaGwTMM", "iconOverride": "" }
   ],
   "quotes": [
     "Technology is incredible!",

--- a/config.json
+++ b/config.json
@@ -6,16 +6,10 @@
   },
   "sections": ["Links"],
   "links": [
-    { "section": "Links", "name": "Gmail", "url": "https://mail.google.com/", "iconOverride": "" },
-    { "section": "Links", "name": "Google Calendar", "url": "https://calendar.google.com/", "iconOverride": "" },
-    { "section": "Links", "name": "Google Drive", "url": "https://drive.google.com/", "iconOverride": "" },
-    { "section": "Links", "name": "Google Docs", "url": "https://docs.google.com/", "iconOverride": "" },
-    { "section": "Links", "name": "GitHub", "url": "https://github.com/", "iconOverride": "" },
-    { "section": "Links", "name": "Stack Overflow", "url": "https://stackoverflow.com/", "iconOverride": "" },
+    { "section": "Links", "name": "Google", "url": "https://www.google.com/", "iconOverride": "" },
     { "section": "Links", "name": "YouTube", "url": "https://www.youtube.com/", "iconOverride": "" },
     { "section": "Links", "name": "Wikipedia", "url": "https://en.wikipedia.org/", "iconOverride": "" },
-    { "section": "Links", "name": "Fireplace", "url": "https://www.youtube.com/watch?v=r2iSxZGYvCs", "iconOverride": "" },
-    { "section": "Links", "name": "San Diego Pacific Beach", "url": "https://www.youtube.com/watch?v=w6P-AaGwTMM", "iconOverride": "" }
+    { "section": "Links", "name": "Amazon", "url": "https://www.amazon.com/", "iconOverride": "" }
   ],
   "quotes": [
     "Technology is incredible!",

--- a/css/style.css
+++ b/css/style.css
@@ -790,6 +790,18 @@ textarea {
     color: var(--muted);
 }
 
+#settings-branding .row {
+    align-items: stretch;
+}
+
+#settings-branding .branding-field {
+    flex: 1 1 240px;
+}
+
+#settings-branding .branding-field-wide {
+    flex: 1 1 100%;
+}
+
 .file-field {
     display: flex;
     align-items: center;

--- a/css/style.css
+++ b/css/style.css
@@ -32,6 +32,7 @@
     --aura-y3: 70%;
     --aura-x4: 78%;
     --aura-y4: 78%;
+    --background-image: none;
 }
 
 * {
@@ -65,6 +66,28 @@ body::before {
 
 body.background-image::before {
     background: linear-gradient(135deg, rgba(8, 10, 16, 0.38), rgba(5, 6, 12, 0.6));
+}
+
+body.background-blur {
+    background-image: none;
+}
+
+body.background-blur::before {
+    background-image: var(--background-image);
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    filter: blur(22px);
+    transform: scale(1.05);
+}
+
+body.background-blur::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(8, 10, 16, 0.38), rgba(5, 6, 12, 0.6));
+    z-index: 0;
 }
 
 .page {

--- a/css/style.css
+++ b/css/style.css
@@ -362,6 +362,8 @@ button:hover,
     display: inline-flex;
     gap: 8px;
     margin-left: 16px;
+    align-items: center;
+    position: relative;
 }
 
 .settings-nav a {
@@ -402,6 +404,45 @@ button:hover,
 .settings-nav button:hover {
     border-color: var(--accent);
     color: var(--text);
+}
+
+.settings-nav-popover {
+    display: none;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(16, 18, 28, 0.9);
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    z-index: 5;
+}
+
+.settings-nav-popover.is-open {
+    display: inline-flex;
+}
+
+.settings-nav-popover input {
+    width: 160px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(10, 12, 20, 0.8);
+    color: var(--text);
+    font-size: 12px;
+}
+
+.settings-nav-popover button {
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(16, 18, 28, 0.8);
+    color: var(--muted);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .settings-nav a.is-active {
@@ -676,6 +717,27 @@ button:hover,
     border: 1px solid transparent;
     background: rgba(12, 14, 22, 0.55);
     transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.link-row-handle {
+    position: absolute;
+    top: 8px;
+    right: 36px;
+    padding: 6px 8px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(10, 12, 20, 0.7);
+    color: var(--muted);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    cursor: grab;
+}
+
+.link-row:hover .link-row-handle,
+.link-row:focus-within .link-row-handle {
+    border-color: var(--accent);
+    color: var(--text);
 }
 
 .link-row:hover,

--- a/css/style.css
+++ b/css/style.css
@@ -572,6 +572,10 @@ button:hover,
     cursor: grab;
 }
 
+.settings-panel.open .link-row {
+    cursor: grab;
+}
+
 .link-row.dragging {
     opacity: 0.5;
 }
@@ -639,6 +643,21 @@ button:hover,
     gap: 12px;
 }
 
+.link-row {
+    position: relative;
+    padding: 12px;
+    border-radius: var(--radius-tight);
+    border: 1px solid transparent;
+    background: rgba(12, 14, 22, 0.55);
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.link-row:hover,
+.link-row:focus-within {
+    border-color: var(--accent);
+    background: rgba(23, 28, 42, 0.7);
+}
+
 .link-row > *,
 .engine-row > * {
     min-width: 0;
@@ -662,6 +681,32 @@ button:hover,
 
 .link-row .field-icon {
     flex: 1 1 220px;
+}
+
+.link-row-remove {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 22px;
+    height: 22px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(10, 12, 20, 0.9);
+    color: var(--muted);
+    font-size: 12px;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    padding: 0;
+}
+
+.link-row:hover .link-row-remove,
+.link-row:focus-within .link-row-remove {
+    opacity: 1;
+    pointer-events: auto;
 }
 
 .link-row button,

--- a/css/style.css
+++ b/css/style.css
@@ -358,6 +358,12 @@ button:hover,
     padding: 12px 0 8px;
 }
 
+.settings-nav-actions {
+    display: inline-flex;
+    gap: 8px;
+    margin-left: 16px;
+}
+
 .settings-nav a {
     display: inline-flex;
     align-items: center;
@@ -373,7 +379,27 @@ button:hover,
     text-transform: uppercase;
 }
 
+.settings-nav button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(16, 18, 28, 0.8);
+    color: var(--muted);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+}
+
 .settings-nav a:hover {
+    border-color: var(--accent);
+    color: var(--text);
+}
+
+.settings-nav button:hover {
     border-color: var(--accent);
     color: var(--text);
 }

--- a/index.html
+++ b/index.html
@@ -189,11 +189,6 @@
             <div class="settings-footer">
                 <div class="footer-credit">Envisioned by Dean Tammam, implemented with Codex.</div>
                 <div class="footer-links">
-                    <a class="footer-link" href="https://github.com/dtammam/mothership-on-main" target="_blank" rel="noopener" aria-label="GitHub repository">
-                        <svg viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M12 2C6.48 2 2 6.58 2 12.26c0 4.53 2.87 8.38 6.84 9.74.5.1.68-.22.68-.48 0-.24-.01-.88-.01-1.72-2.78.62-3.37-1.37-3.37-1.37-.45-1.2-1.11-1.52-1.11-1.52-.9-.63.07-.62.07-.62 1 .07 1.52 1.06 1.52 1.06.89 1.56 2.34 1.11 2.91.85.09-.67.35-1.11.63-1.37-2.22-.26-4.56-1.15-4.56-5.1 0-1.13.39-2.05 1.03-2.78-.1-.26-.45-1.3.1-2.7 0 0 .85-.28 2.78 1.06a9.5 9.5 0 0 1 5.06 0c1.93-1.34 2.78-1.06 2.78-1.06.55 1.4.2 2.44.1 2.7.64.73 1.03 1.65 1.03 2.78 0 3.96-2.35 4.84-4.58 5.1.36.33.68.97.68 1.96 0 1.42-.01 2.56-.01 2.91 0 .27.18.59.69.48A10.24 10.24 0 0 0 22 12.26C22 6.58 17.52 2 12 2z"/>
-                        </svg>
-                    </a>
                     <a class="footer-link" href="https://deantammam.substack.com/" target="_blank" rel="noopener" aria-label="Substack">
                         <svg viewBox="0 0 24 24" aria-hidden="true">
                             <path d="M4 5h16v3H4V5zm0 5h16v3H4v-3zm0 5h16v3l-8 4-8-4v-3z"/>

--- a/index.html
+++ b/index.html
@@ -62,6 +62,11 @@
                     <a href="#settings-backgrounds">Backgrounds</a>
                     <a href="#settings-layout">Layout</a>
                     <a href="#settings-links">Links</a>
+                    <span class="settings-nav-actions">
+                        <button type="button" data-action="quick-add-link">New Link</button>
+                        <button type="button" data-action="quick-add-section">New Category</button>
+                        <button type="button" data-action="quick-add-engine">New Search</button>
+                    </span>
                 </nav>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
                     </div>
                 </div>
 
-                <form id="search-form" action="" method="get" target="_blank">
+                <form id="search-form" action="" method="get">
                     <select id="search-engine" aria-label="Search engine"></select>
                     <input id="search-input" type="text" name="q" placeholder="Find what you're looking for" required>
                     <button type="submit">Search</button>
@@ -209,13 +209,13 @@
                 </label>
                 <label class="field field-section">
                     Section
-                    <input data-field="section" type="text" placeholder="Primary">
+                    <input data-field="section" type="text" placeholder="Links">
                 </label>
                 <label class="field field-icon">
                     Icon override
                     <input data-field="icon" type="file" accept="image/*">
                 </label>
-                <button data-action="remove-link" class="ghost-button" type="button">Remove</button>
+                <button data-action="remove-link" class="link-row-remove" type="button" aria-label="Remove link">X</button>
             </div>
         </template>
 

--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
                 </div>
             </div>
             <div class="settings-footer">
-                <div class="footer-credit">Envisioned by Dean Tammam, implemented with Codex.</div>
+                <div class="footer-credit">New-tab productivity, built by Dean with AI.</div>
                 <div class="footer-links">
                     <a class="footer-link" href="https://deantammam.substack.com/" target="_blank" rel="noopener" aria-label="Substack">
                         <svg viewBox="0 0 24 24" aria-hidden="true">

--- a/index.html
+++ b/index.html
@@ -79,6 +79,15 @@
                 <h3>Config</h3>
                 <div class="row">
                     <button id="export-config" class="ghost-button" type="button">Download config</button>
+                    <label class="field">
+                        Import mode
+                        <select id="import-config-mode">
+                            <option value="all">Import all</option>
+                            <option value="quotes">Import quotes</option>
+                            <option value="search">Import searches</option>
+                            <option value="links">Import links</option>
+                        </select>
+                    </label>
                     <label class="file-field">
                         <span class="file-button">Choose file</span>
                         <span id="import-config-name" class="file-name">No file chosen</span>
@@ -112,11 +121,6 @@
                         <select id="default-engine"></select>
                     </label>
                 </div>
-                <label class="file-field">
-                    <span class="file-button">Import engines</span>
-                    <span id="search-upload-name" class="file-name">No file selected</span>
-                    <input id="search-upload" type="file" accept=".json">
-                </label>
             </div>
 
             <div id="settings-quotes" class="settings-section">

--- a/index.html
+++ b/index.html
@@ -66,6 +66,11 @@
                         <button type="button" data-action="quick-add-link">New Link</button>
                         <button type="button" data-action="quick-add-section">New Category</button>
                         <button type="button" data-action="quick-add-engine">New Search</button>
+                        <form class="settings-nav-popover" data-nav-popover>
+                            <input id="quick-section-name" type="text" placeholder="Category name" aria-label="Category name">
+                            <button type="submit">Add</button>
+                            <button type="button" data-action="quick-cancel-section">Cancel</button>
+                        </form>
                     </span>
                 </nav>
             </div>
@@ -203,6 +208,7 @@
 
         <template id="link-row-template">
             <div class="editor-row link-row" data-link-row>
+                <button class="link-row-handle" type="button" aria-label="Drag link">Drag</button>
                 <img class="icon-preview" alt="" width="24" height="24">
                 <label class="field field-name">
                     Name

--- a/index.html
+++ b/index.html
@@ -189,17 +189,17 @@
             <div class="settings-footer">
                 <div class="footer-credit">New-tab productivity, built by Dean with AI.</div>
                 <div class="footer-links">
-                    <a class="footer-link" href="https://deantammam.substack.com/" target="_blank" rel="noopener" aria-label="Substack">
+                    <a class="footer-link" href="https://deantammam.substack.com/" aria-label="Substack">
                         <svg viewBox="0 0 24 24" aria-hidden="true">
                             <path d="M4 5h16v3H4V5zm0 5h16v3H4v-3zm0 5h16v3l-8 4-8-4v-3z"/>
                         </svg>
                     </a>
-                    <a class="footer-link" href="https://www.linkedin.com/in/dean-tammam-15b4775a" target="_blank" rel="noopener" aria-label="LinkedIn">
+                    <a class="footer-link" href="https://www.linkedin.com/in/dean-tammam-15b4775a" aria-label="LinkedIn">
                         <svg viewBox="0 0 24 24" aria-hidden="true">
                             <path d="M6.94 8.5H3.5V21h3.44V8.5zM5.22 3.5C4.1 3.5 3.2 4.4 3.2 5.5c0 1.1.9 2 2.02 2s2.02-.9 2.02-2c0-1.1-.9-2-2.02-2zM20.5 13.1c0-3.2-1.7-4.7-4-4.7-1.8 0-2.7 1-3.1 1.8h-.05V8.5H9.9V21h3.44v-6.2c0-1.6.3-3.1 2.3-3.1 2 0 2 1.9 2 3.2V21h3.46v-7.9z"/>
                         </svg>
                     </a>
-                    <a class="footer-link" href="https://chatgpt.com/features/codex" target="_blank" rel="noopener" aria-label="OpenAI">
+                    <a class="footer-link" href="https://chatgpt.com/features/codex" aria-label="OpenAI">
                         <svg viewBox="0 0 24 24" aria-hidden="true">
                             <path d="M22.27 8.81a4.9 4.9 0 0 0-2.1-2.1 5.03 5.03 0 0 0 .16-2.33 5.12 5.12 0 0 0-7.07-1.87 5.03 5.03 0 0 0-2.33-.16 4.9 4.9 0 0 0-2.1-2.1 5.12 5.12 0 0 0-7.07 7.07 4.9 4.9 0 0 0 2.1 2.1 5.03 5.03 0 0 0-.16 2.33 5.12 5.12 0 0 0 7.07 1.87 5.03 5.03 0 0 0 2.33.16 4.9 4.9 0 0 0 2.1 2.1 5.12 5.12 0 0 0 7.07-7.07 4.9 4.9 0 0 0-2.1-2.1 5.03 5.03 0 0 0 .16-2.33zM12 7.02a2.98 2.98 0 0 1 2.58 1.5 2.97 2.97 0 0 1-1.1 4.08 2.98 2.98 0 0 1-4.08-1.1 2.97 2.97 0 0 1 1.1-4.08A2.98 2.98 0 0 1 12 7.02z"/>
                         </svg>

--- a/index.html
+++ b/index.html
@@ -142,6 +142,7 @@
                             <option value="gradient_signature">Signature gradient</option>
                             <option value="gradient_dynamic">Dynamic gradient</option>
                             <option value="images">Uploaded images</option>
+                            <option value="images_blur">Uploaded images (blurred)</option>
                         </select>
                     </label>
                 </div>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
                         Header
                         <input id="branding-title" type="text" placeholder="Mothership on Main">
                     </label>
-                    <label class="field branding-field">
+                    <label class="field branding-field branding-field-wide">
                         Subheader
                         <input id="branding-subtitle" type="text" placeholder="Your favorite bookmark replacement tool">
                     </label>

--- a/index.html
+++ b/index.html
@@ -140,9 +140,15 @@
                         Mode
                         <select id="background-mode">
                             <option value="gradient_signature">Signature gradient</option>
-                            <option value="gradient_dynamic">Dynamic gradient</option>
                             <option value="images">Uploaded images</option>
                             <option value="images_blur">Uploaded images (blurred)</option>
+                            <option value="gradient_dynamic">Dynamic gradient from favicons</option>
+                            <option value="gradient_soda">Soda pop gradient</option>
+                            <option value="gradient_azure">Azure skies gradient</option>
+                            <option value="gradient_github_dark">Octocat night gradient</option>
+                            <option value="gradient_dracula">Dracula dusk gradient</option>
+                            <option value="gradient_synthwave">Synthwave sunset gradient</option>
+                            <option value="gradient_daylight">Daylight bloom gradient</option>
                         </select>
                     </label>
                 </div>

--- a/js/script.js
+++ b/js/script.js
@@ -724,12 +724,18 @@ function setupSettings() {
     });
 
     exportConfig.addEventListener("click", () => {
-        const data = JSON.stringify(collectConfigFromEditors(), null, 2);
+        const config = collectConfigFromEditors();
+        const data = JSON.stringify(config, null, 2);
         const blob = new Blob([data], { type: "application/json" });
         const url = URL.createObjectURL(blob);
         const anchor = document.createElement("a");
         anchor.href = url;
-        anchor.download = "mothership-config.json";
+        const title = (config.branding?.title || "mothership")
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/(^-|-$)+/g, "");
+        const timestamp = new Date().toISOString().replace(/[:T]/g, "-").replace(/\..+/, "");
+        anchor.download = `${title || "mothership"}-${timestamp}.json`;
         anchor.click();
         URL.revokeObjectURL(url);
     });

--- a/js/script.js
+++ b/js/script.js
@@ -483,6 +483,8 @@ function setupSettings() {
     const sectionsContainer = document.getElementById("sections-container");
     const layoutMaxColumns = document.getElementById("layout-max-columns");
     const settingsNav = document.querySelector(".settings-nav");
+    const quickSectionForm = document.querySelector("[data-nav-popover]");
+    const quickSectionInput = document.getElementById("quick-section-name");
 
     setupSettingsNav(settingsPanel, settingsNav);
     canRearrangeEditor = () => settingsPanel.classList.contains("open");
@@ -570,13 +572,19 @@ function setupSettings() {
             row?.querySelector('[data-field="name"]')?.focus();
         }
         if (action === "quick-add-section") {
-            const sectionName = window.prompt("New category name");
-            if (!sectionName) {
+            if (quickSectionForm) {
+                quickSectionForm.classList.toggle("is-open");
+            }
+            quickSectionInput?.focus({ preventScroll: true });
+        }
+        if (action === "quick-cancel-section") {
+            if (!quickSectionForm) {
                 return;
             }
-            ensureLinksSection(sectionName);
-            const section = document.querySelector(`[data-section-block][data-section="${sectionName}"]`);
-            section?.scrollIntoView({ block: "start" });
+            quickSectionForm.classList.remove("is-open");
+            if (quickSectionInput) {
+                quickSectionInput.value = "";
+            }
         }
         if (action === "quick-add-engine") {
             addEngineRow({ id: "", label: "", url: "", queryParam: "q" });
@@ -598,6 +606,44 @@ function setupSettings() {
         }
         if (action === "remove-section") {
             event.target.closest("[data-section-block]")?.remove();
+        }
+    });
+
+    if (quickSectionForm && quickSectionInput) {
+        quickSectionForm.addEventListener("submit", (event) => {
+            event.preventDefault();
+            const sectionName = quickSectionInput.value.trim();
+            if (!sectionName) {
+                return;
+            }
+            ensureLinksSection(sectionName);
+            const section = document.querySelector(`[data-section-block][data-section="${sectionName}"]`);
+            section?.scrollIntoView({ block: "start" });
+            quickSectionInput.value = "";
+            quickSectionForm.classList.remove("is-open");
+        });
+    }
+
+    document.addEventListener("keydown", async (event) => {
+        if (event.key !== "Escape") {
+            return;
+        }
+        if (quickSectionForm?.classList.contains("is-open")) {
+            quickSectionForm.classList.remove("is-open");
+            if (quickSectionInput) {
+                quickSectionInput.value = "";
+            }
+            return;
+        }
+        if (settingsPanel.classList.contains("open")) {
+            settingsPanel.classList.remove("open");
+            settingsPanel.setAttribute("aria-hidden", "true");
+            setRearrangeMode(false);
+            updateLinkRowDragState();
+            return;
+        }
+        if (isRearranging) {
+            setRearrangeMode(false);
         }
     });
 

--- a/js/script.js
+++ b/js/script.js
@@ -1574,6 +1574,30 @@ function applyGradientMode(mode) {
         applyDynamicGradient();
         return;
     }
+    if (mode === "gradient_soda") {
+        applySodaGradient();
+        return;
+    }
+    if (mode === "gradient_github_dark") {
+        applyGithubDarkGradient();
+        return;
+    }
+    if (mode === "gradient_azure") {
+        applyAzureGradient();
+        return;
+    }
+    if (mode === "gradient_dracula") {
+        applyDraculaGradient();
+        return;
+    }
+    if (mode === "gradient_synthwave") {
+        applySynthwaveGradient();
+        return;
+    }
+    if (mode === "gradient_daylight") {
+        applyDaylightGradient();
+        return;
+    }
     applySignatureGradient();
 }
 
@@ -1583,6 +1607,66 @@ function applySignatureGradient() {
         [79, 172, 254],
         [255, 200, 124],
         [137, 247, 254]
+    ];
+    setAuraPalette(palette);
+}
+
+function applySodaGradient() {
+    const palette = [
+        [116, 255, 216],
+        [94, 215, 255],
+        [255, 120, 164],
+        [255, 212, 88]
+    ];
+    setAuraPalette(palette);
+}
+
+function applyGithubDarkGradient() {
+    const palette = [
+        [13, 17, 23],
+        [22, 27, 34],
+        [48, 54, 61],
+        [88, 96, 105]
+    ];
+    setAuraPalette(palette);
+}
+
+function applyAzureGradient() {
+    const palette = [
+        [0, 120, 212],
+        [0, 91, 172],
+        [80, 188, 255],
+        [0, 183, 255]
+    ];
+    setAuraPalette(palette);
+}
+
+function applyDraculaGradient() {
+    const palette = [
+        [40, 42, 54],
+        [68, 71, 90],
+        [189, 147, 249],
+        [255, 121, 198]
+    ];
+    setAuraPalette(palette);
+}
+
+function applySynthwaveGradient() {
+    const palette = [
+        [255, 98, 196],
+        [138, 99, 255],
+        [79, 230, 255],
+        [255, 197, 109]
+    ];
+    setAuraPalette(palette);
+}
+
+function applyDaylightGradient() {
+    const palette = [
+        [255, 241, 198],
+        [255, 214, 170],
+        [255, 170, 204],
+        [186, 233, 255]
     ];
     setAuraPalette(palette);
 }
@@ -1599,7 +1683,8 @@ async function applyDynamicGradient() {
         applySignatureGradient();
         return;
     }
-    const unique = shuffleArray(filtered).slice(0, 4);
+    const boosted = filtered.map((color) => boostColor(color, 0.3));
+    const unique = shuffleArray(boosted).slice(0, 4);
     setAuraPalette(unique);
 }
 
@@ -1689,6 +1774,10 @@ function shuffleArray(list) {
         [array[i], array[j]] = [array[j], array[i]];
     }
     return array;
+}
+
+function boostColor(color, amount) {
+    return color.map((channel) => Math.min(255, Math.max(0, Math.round(channel + (255 - channel) * amount))));
 }
 
 function collectSectionsFromEditor() {

--- a/js/script.js
+++ b/js/script.js
@@ -273,20 +273,36 @@ function renderBackground(config) {
     const mode = config.backgroundMode || "images";
     if (mode === "images") {
         document.body.classList.add("background-image");
-        renderImageBackground(config.backgrounds);
+        document.body.classList.remove("background-blur");
+        renderImageBackground(config.backgrounds, false);
+        return;
+    }
+    if (mode === "images_blur") {
+        document.body.classList.remove("background-image");
+        document.body.classList.add("background-blur");
+        renderImageBackground(config.backgrounds, true);
         return;
     }
     document.body.classList.remove("background-image");
+    document.body.classList.remove("background-blur");
     document.body.style.backgroundImage = "";
+    document.body.style.setProperty("--background-image", "none");
     applyGradientMode(mode);
 }
 
-function renderImageBackground(backgrounds) {
+function renderImageBackground(backgrounds, useBlur) {
     if (!backgrounds.length) {
         document.body.style.backgroundImage = "";
+        document.body.style.setProperty("--background-image", "none");
         return;
     }
     const random = backgrounds[Math.floor(Math.random() * backgrounds.length)];
+    if (useBlur) {
+        document.body.style.backgroundImage = "";
+        document.body.style.setProperty("--background-image", `url("${random}")`);
+        return;
+    }
+    document.body.style.setProperty("--background-image", "none");
     document.body.style.backgroundImage = `url("${random}")`;
 }
 
@@ -669,6 +685,11 @@ function setupSettings() {
                 const dataUrl = await fileToDataUrl(file);
                 addBackgroundRow(dataUrl);
                 storeBackgroundThumb(dataUrl);
+            }
+            if (files.length) {
+                backgroundMode.value = "images";
+                activeConfig = { ...activeConfig, backgroundMode: "images" };
+                renderBackground(activeConfig);
             }
             event.target.value = "";
         });

--- a/js/script.js
+++ b/js/script.js
@@ -563,6 +563,29 @@ function setupSettings() {
         if (!action) {
             return;
         }
+        if (action === "quick-add-link") {
+            const row = addLinkRow();
+            const section = document.getElementById("settings-links");
+            section?.scrollIntoView({ block: "start" });
+            row?.querySelector('[data-field="name"]')?.focus();
+        }
+        if (action === "quick-add-section") {
+            const sectionName = window.prompt("New category name");
+            if (!sectionName) {
+                return;
+            }
+            ensureLinksSection(sectionName);
+            const section = document.querySelector(`[data-section-block][data-section="${sectionName}"]`);
+            section?.scrollIntoView({ block: "start" });
+        }
+        if (action === "quick-add-engine") {
+            addEngineRow({ id: "", label: "", url: "", queryParam: "q" });
+            refreshDefaultEngineOptions();
+            const section = document.getElementById("settings-search");
+            section?.scrollIntoView({ block: "start" });
+            const lastEngine = document.querySelector("#engines-editor [data-engine-row]:last-child");
+            lastEngine?.querySelector('[data-field="id"]')?.focus();
+        }
         if (action === "remove-link") {
             event.target.closest("[data-link-row]")?.remove();
         }
@@ -612,8 +635,7 @@ function setupSettings() {
         updateFileLabel(quotesUploadName, [file], "No file selected");
         const text = await file.text();
         const textarea = document.getElementById("quotes-editor");
-        const existing = textarea.value ? `${textarea.value}\n` : "";
-        textarea.value = `${existing}${text}`.trim();
+        textarea.value = text.trim();
         event.target.value = "";
     });
 
@@ -1114,6 +1136,7 @@ function addLinkRow(sectionName) {
         container.appendChild(row);
     }
     updateLinkRowDragState();
+    return row;
 }
 
 function addBackgroundRow(value, containerOverride, templateOverride) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,18 @@
 {
     "name": "Mothership on Main",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "manifest_version": 3,
     "description": "Replaces the new tab page with a configurable command center for links, search, quotes, and backgrounds.",
     "chrome_url_overrides": {
         "newtab": "index.html"
     },
-    "permissions": ["storage"],
-    "host_permissions": ["https://*/*", "http://*/*"],
+    "permissions": [
+        "storage"
+    ],
+    "host_permissions": [
+        "https://*/*",
+        "http://*/*"
+    ],
     "action": {
         "default_icon": {
             "16": "images/icon.png",
@@ -17,4 +22,3 @@
         }
     }
 }
-

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,15 @@ This extension does the following:
 
 ## License
 
-[MIT](license)
+[MIT](LICENSE)
+
+## Privacy
+
+See [PRIVACY](PRIVACY.md).
+
+## Changelog
+
+See [CHANGELOG](CHANGELOG.md).
 
 ## Credits
 

--- a/readme.md
+++ b/readme.md
@@ -59,15 +59,6 @@ This extension does the following:
 - The Quotes heading can be renamed in Customize to match your brand voice.
 - Large background images are stored full-size, but the editor uses lightweight thumbnails for speed.
 
-## Testing checklist
-
-- Load the extension as unpacked and open a new tab; confirm the page renders without errors.
-- Search: submit a query and verify it opens in the same tab.
-- Links: click a link and verify it opens in the same tab; switch to Rearrange and move links/sections, then Finish.
-- Customize: add a link, category, and search engine from the top pills; reorder links inside Customize.
-- Import/export: export config, then import it; import quotes and confirm they replace existing lines.
-- Backgrounds: switch between gradients, uploaded images, and blurred images; upload an image and confirm the dropdown switches to Uploaded images.
-
 ## License
 
 [MIT](license)

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,15 @@ This extension does the following:
 - The Quotes heading can be renamed in Customize to match your brand voice.
 - Large background images are stored full-size, but the editor uses lightweight thumbnails for speed.
 
+## Testing checklist
+
+- Load the extension as unpacked and open a new tab; confirm the page renders without errors.
+- Search: submit a query and verify it opens in the same tab.
+- Links: click a link and verify it opens in the same tab; switch to Rearrange and move links/sections, then Finish.
+- Customize: add a link, category, and search engine from the top pills; reorder links inside Customize.
+- Import/export: export config, then import it; import quotes and confirm they replace existing lines.
+- Backgrounds: switch between gradients, uploaded images, and blurred images; upload an image and confirm the dropdown switches to Uploaded images.
+
 ## License
 
 [MIT](license)

--- a/readme.md
+++ b/readme.md
@@ -22,9 +22,9 @@ The original inspiration came from a coworker pointing out that my clerical work
 ## Highlights
 
 - New tab + home replacement with sections and rich link cards
-- Built-in Customize panel with jump navigation, branding, quotes, backgrounds, search engines, and links
+- Built-in Customize panel with jump navigation, quick-add pills, branding, quotes, backgrounds, search engines, and links
 - Favicon caching with overrides and a dynamic gradient background
-- Drag to reorder sections and links, including cross-section moves
+- Drag to reorder sections and links on the main page and inside Customize
 
 ## Installation
 
@@ -48,11 +48,14 @@ This extension does the following:
 - Provides a config-backed multi-search window
 - Displays quotes/notes on page load (brandable heading)
 - Changes the background image on page load (including uploads, with lightweight thumbnails in Customize)
+- Keeps search and link navigation in the current tab
 - Allows for efficient web browser usage with custom links and favicon caching/overrides
 
 ## Customize tips
 
-- Use the jump pills at the top of Customize to hop between sections.
+- Use the jump pills at the top of Customize to hop between sections; use the New Link/Category/Search pills for quick adds.
+- Drag links directly in Customize to reorder within and across categories.
+- The topmost category becomes the default for new links.
 - The Quotes heading can be renamed in Customize to match your brand voice.
 - Large background images are stored full-size, but the editor uses lightweight thumbnails for speed.
 

--- a/readme.md
+++ b/readme.md
@@ -28,18 +28,9 @@ The original inspiration came from a coworker pointing out that my clerical work
 
 ## Installation
 
-1. Download this project in a location of your choosing
+Install from the Microsoft Edge Add-ons store (recommended).
 
-2. Open the extension and click `Customize` to manage links, images, quotes, and search engines.
-    - Text config (links/quotes/search/sections) syncs via `chrome.storage.sync` across devices when available
-    - Uploaded images and favicon overrides stay local, but export/import includes them
-    - The default config lives in `config.json`
-
-4. In Edge/Chrome, go to `Settings`, `Manage Extensions`, `Load Unpacked` and select the folder you downloaded
-    - Once selected, you'll see it pop up in the list of extensions, enabled
-    - Open a new tab to confirm that it worked
-
-5. To modify in the future, open a new tab and click `Customize`. A store-published version for Chrome and Edge is coming soon.
+If you are working on the codebase locally, you can still load it as an unpacked extension in Edge/Chrome.
 
 ## Usage
 


### PR DESCRIPTION
- Overhauled Customize experience with quick‑add pills, inline category add, and in‑panel drag‑and‑drop.
- Added multiple new gradient modes, blurred image backgrounds, and boosted dynamic favicon gradient intensity.
- Unified default links into a single “Links” section with a simpler four‑link starter set.
- Consolidated config import modes (all/quotes/search/links), improved quote import replacement, and removed standalone search import.
- Same‑tab navigation for searches and links; export filenames now include title + timestamp.
- Added NOTICE, PRIVACY policy, and CHANGELOG; refreshed README and footer credit.