### PR TITLE
Fix collapse/expand E2E tests — use dispatchEvent

### DIFF
--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -156,9 +156,9 @@ test.describe("Section interactions", () => {
         const grid = section.locator(".links-grid");
         await expect(grid).toBeVisible();
 
-        // Collapse button has pointer-events:none outside rearrange mode
-        // but the click handler still works — use force to bypass CSS.
-        await section.locator(".section-collapse").click({ force: true });
+        // Collapse button has pointer-events:none outside rearrange mode;
+        // dispatchEvent bypasses CSS pointer-events entirely.
+        await section.locator(".section-collapse").dispatchEvent("click");
         await page.waitForTimeout(500);
 
         const updatedSection = page.locator(".section").first();
@@ -171,7 +171,7 @@ test.describe("Section interactions", () => {
         const expandBtn = section.locator(".section-collapse");
         await expect(expandBtn).toHaveText("Expand");
 
-        await expandBtn.click({ force: true });
+        await expandBtn.dispatchEvent("click");
         await page.waitForTimeout(500);
 
         const updatedSection = page.locator(".section").first();


### PR DESCRIPTION
## Summary
- Fix `#settings-cancel` selector → `#settings-cancel-bottom`
- Use `dispatchEvent("click")` instead of `force: true` for collapse/expand buttons — `pointer-events: none` blocks even forced clicks, but `dispatchEvent` bypasses CSS entirely
- Follows up on #15 which fixed the service worker timeout

## Test plan
- [ ] CI `quality-gate` Playwright step passes — all 16 E2E tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)