### PR TITLE
Add "Mothership Status Update" dialog for post-upgrade release highli…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ Active plans currently in progress:
 
 Completed plans:
 
+- `2026-03-15-whats-new.md` — "What's New" dialog: one-time post-upgrade modal with release highlights, settings footer link, accordion for past versions
 - `2026-03-14-feature-batch.md` — 7 features: bookmark import, CI hooks + Playwright, open-all-links, collapse without rearrange, section select bug fix, true section hiding, version label (v1.5.0)
 - `2026-03-13-module-split.md` — split monolithic script.js into 7 focused modules (tech debt #1)
 - `2026-03-13-dom-test-coverage.md` — DOM rendering tests, all C domains upgraded to A

--- a/css/style.css
+++ b/css/style.css
@@ -1350,3 +1350,200 @@ textarea {
     opacity: 1;
     transform: translateY(0);
 }
+
+/* ── What's New dialog ── */
+.whats-new-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.whats-new-dialog {
+    background: rgba(12, 14, 22, 0.97);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 0;
+    width: min(520px, 90vw);
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.whats-new-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 24px 16px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.whats-new-header h3 {
+    margin: 0;
+    font-size: 1.15rem;
+    color: var(--text);
+    font-family: var(--font-display);
+}
+
+.whats-new-close {
+    background: none;
+    border: none;
+    color: var(--muted);
+    font-size: 1.4rem;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+    transition: color 0.15s ease;
+}
+
+.whats-new-close:hover {
+    color: var(--text);
+}
+
+.whats-new-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.whats-new-release {
+    display: flex;
+    flex-direction: column;
+}
+
+.whats-new-version {
+    background: none;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-tight);
+    color: var(--muted);
+    font-family: var(--font-sans);
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 10px 14px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    transition:
+        background 0.15s ease,
+        color 0.15s ease;
+}
+
+.whats-new-version:hover {
+    background: var(--surface);
+    color: var(--text);
+}
+
+.whats-new-version.current {
+    color: var(--accent);
+    border-color: rgba(255, 138, 61, 0.25);
+}
+
+.whats-new-chevron {
+    font-size: 0.65rem;
+    opacity: 0.6;
+}
+
+.whats-new-items {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 14px 4px;
+    overflow: hidden;
+    max-height: 600px;
+    transition:
+        max-height 0.25s ease,
+        padding 0.25s ease,
+        opacity 0.2s ease;
+    opacity: 1;
+}
+
+.whats-new-items.collapsed {
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    opacity: 0;
+}
+
+.whats-new-item {
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: var(--muted);
+    padding-left: 8px;
+    border-left: 2px solid rgba(255, 255, 255, 0.08);
+}
+
+.whats-new-item strong {
+    color: var(--text);
+    font-weight: 600;
+}
+
+.whats-new-release-note {
+    margin: 8px 0 0;
+    padding-left: 8px;
+    font-size: 0.8rem;
+    color: var(--muted);
+    font-style: italic;
+}
+
+.whats-new-footer {
+    padding: 16px 24px 20px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+.whats-new-feedback {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--muted);
+    text-align: center;
+}
+
+.whats-new-got-it {
+    background: var(--accent);
+    color: #000;
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-tight);
+    padding: 8px 28px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition:
+        background 0.15s ease,
+        transform 0.1s ease;
+}
+
+.whats-new-got-it:hover {
+    background: var(--accent-strong);
+    transform: translateY(-1px);
+}
+
+/* "What's New" link button in settings footer (inline with version label) */
+.whats-new-btn {
+    display: inline;
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-size: inherit;
+    cursor: pointer;
+    padding: 0;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    opacity: 0.8;
+    transition: opacity 0.15s ease;
+    font-family: inherit;
+}
+
+.whats-new-btn:hover {
+    opacity: 1;
+}

--- a/docs/exec-plans/completed/2026-03-15-whats-new.md
+++ b/docs/exec-plans/completed/2026-03-15-whats-new.md
@@ -1,0 +1,218 @@
+# What's New Dialog
+
+**Status:** Complete
+**Created:** 2026-03-15
+
+## Goal
+
+Add a "What's New" modal that surfaces release highlights to users after an extension upgrade. The dialog should feel like a quick, friendly tour — not a changelog dump. It appears once per version automatically, and is re-openable from the settings menu at any time.
+
+## Non-goals
+
+- Auto-update mechanism (Edge handles extension updates)
+- Fetching release notes from a remote source
+- Analytics or telemetry on dialog views
+- Migrating existing users' "last seen version" retroactively (v1.5.0 will be the first entry; users upgrading from pre-1.5.0 will see it on first load)
+
+## Constraints
+
+- Plain HTML + CSS + JavaScript only (no build tools, no frameworks)
+- Must not affect performance budgets — the dialog loads lazily after the page is fully rendered
+- Must inherit the existing dark-themed visual style (reuse bookmark picker modal patterns)
+- Storage mechanism must not interfere with the v2 chunked config system
+- Must work even if `chrome.storage.sync` is unavailable (graceful fallback: just don't show)
+
+## Current state
+
+- No "What's New" mechanism exists
+- Version is read from `manifest.json` at runtime in `init.js` (`renderVersionLabel()`)
+- The bookmark folder picker modal in `customize.js` is the closest UI precedent — overlay + centered panel with header, scrollable content, and footer actions
+- The settings panel footer already shows the version label (`#version-label`)
+- Storage keys use the `msom:` prefix convention (defined in `constants.js`)
+
+## Proposed approach
+
+### Version content: hardcoded JS object vs. JSON manifest
+
+**Option A — Hardcoded JS object in a dedicated file (`js/whats-new-content.js`)**
+
+```js
+const WHATS_NEW_RELEASES = [
+    {
+        version: "1.5.0",
+        date: "2026-03-14",
+        highlights: [
+            {
+                title: "Section hiding",
+                description: "Hide sections you don't need — unhide them later in their original position."
+            }
+            // ...
+        ]
+    }
+];
+```
+
+Pros:
+
+- Simple, no fetch/parse step
+- Easy to add new entries — just prepend to the array
+- Loads synchronously with the page (no async file read)
+- Can include rich formatting in description strings (inline HTML or markdown-like)
+
+Cons:
+
+- Content lives in JS, not a pure data file
+- Slightly harder for non-dev contributors to edit (but this is a solo project)
+
+**Option B — Separate `whats-new.json` data file**
+
+Pros:
+
+- Clean data/code separation
+- Could be consumed by other tools (release scripts, store listing)
+
+Cons:
+
+- Requires an async `fetch()` call to load
+- Adds a network request (even if local) to the critical path or requires lazy loading
+- JSON doesn't support comments or trailing commas (minor annoyance)
+- Extra file to maintain
+
+**Recommendation: Option A (JS object).** It's simpler, loads synchronously, and aligns with the existing pattern of constants/config living in JS files. The content is small and changes infrequently (once per release). A dedicated `js/whats-new-content.js` file keeps the data separate from the logic while avoiding the async fetch overhead.
+
+### Storage mechanism: tracking last-seen version
+
+Use a single `chrome.storage.local` key (not sync — this is per-device UI state, not user config):
+
+```
+Key: "msom:whatsNewLastSeen"
+Value: "1.5.0" (string — the version string the user last dismissed)
+```
+
+Why `local` instead of `sync`:
+
+- This is device-local UI state, not configuration data worth syncing across devices
+- Avoids consuming any of the tight sync quota
+- If a user has multiple devices, they'll see "What's New" on each device after upgrade — which is fine
+
+On page load (after main render completes):
+
+1. Read `msom:whatsNewLastSeen` from `chrome.storage.local`
+2. Read current version from `manifest.json` (already fetched by `renderVersionLabel()`)
+3. If `lastSeen !== currentVersion` → show the dialog automatically
+4. When user dismisses → write `currentVersion` to `msom:whatsNewLastSeen`
+
+Edge case: If storage read fails, don't show the dialog (fail closed — no annoyance).
+
+### Modal structure and visual style
+
+Reuse the bookmark picker modal's visual DNA:
+
+```
+.whats-new-overlay          (fixed overlay, same as .bookmark-picker-overlay)
+  .whats-new-dialog         (centered panel, same surface/border/shadow as .bookmark-picker)
+    .whats-new-header       (title + version badge + close button)
+    .whats-new-body         (scrollable content area)
+      .whats-new-release    (one per version)
+        .whats-new-version  (version heading, e.g., "v1.5.0 — March 2026")
+        .whats-new-items    (list of highlights)
+          .whats-new-item   (icon/emoji + title + description)
+    .whats-new-footer       (feedback line + dismiss button)
+```
+
+Key style decisions:
+
+- Same overlay (`rgba(0,0,0,0.6)`), same panel background (`rgba(12,14,22,0.97)`), same border/radius/shadow
+- Current version section is expanded by default; previous versions are collapsed (accordion)
+- Each highlight item gets a small icon or accent marker to make it scannable
+- Footer includes a plain-text feedback line: "Questions? Feedback? Comments? Reach out to Dean!" (no link — all users know him personally)
+- "Got it" dismiss button below the feedback line (primary accent style)
+- Close (×) button in the header for quick dismiss
+- Max height `70vh` with internal scroll, same as bookmark picker
+
+### Settings menu integration
+
+Add a "What's New" button/link near the version label in the settings panel footer. Clicking it opens the same dialog, showing all version entries (not just current).
+
+### File organization
+
+| File                      | Changes                                                       |
+| ------------------------- | ------------------------------------------------------------- |
+| `js/whats-new-content.js` | **New.** Version content data (array of release objects)      |
+| `js/whats-new.js`         | **New.** Dialog rendering, show/dismiss logic, storage check  |
+| `js/constants.js`         | Add `WHATS_NEW_LAST_SEEN_KEY` constant                        |
+| `js/init.js`              | Call `checkWhatsNew()` after main render completes            |
+| `index.html`              | Add `<script>` tags for the two new JS files                  |
+| `css/style.css`           | Add `.whats-new-*` styles (modeled on `.bookmark-picker-*`)   |
+| `index.html`              | Add "What's New" button near version label in settings footer |
+
+### Adding future releases
+
+To add a new version's highlights:
+
+1. Open `js/whats-new-content.js`
+2. Prepend a new object to the `WHATS_NEW_RELEASES` array
+3. The dialog automatically shows the newest entry first
+
+No other files need to change. The version comparison logic uses `manifest.json`'s `version` field, which is already bumped as part of the release process.
+
+## Alternatives considered
+
+| Alternative                                  | Why rejected                                                                        |
+| -------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Toast/banner instead of modal                | Too small for multiple highlights; doesn't scale to multiple versions               |
+| Notification API (browser)                   | Requires extra permissions; feels system-level, not in-app                          |
+| Inline "what's new" section on the main page | Clutters the main UI; hard to dismiss permanently                                   |
+| Sync storage for last-seen tracking          | Wastes sync quota on device-local UI state                                          |
+| Markdown content file                        | Requires a parser; unnecessary complexity for short highlight blurbs                |
+| `whats-new.json` data file                   | Requires async fetch; no meaningful benefit for a solo project (see Option B above) |
+
+## Risks and mitigations
+
+| Risk                                                   | Mitigation                                                                                                                              |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Dialog annoys users on every device after sync update  | Use `chrome.storage.local` — per-device tracking means they see it once per device, which is acceptable                                 |
+| Version string format changes break comparison         | Use simple string equality (`!==`), not semver parsing. If the version string changes, the dialog shows — which is the correct behavior |
+| Content file grows large over many releases            | Accordion collapses older versions. Could cap displayed versions to last N if needed (not expected to be an issue for years)            |
+| Modal conflicts with bookmark picker or other overlays | Check if another overlay is visible before auto-showing; skip if so                                                                     |
+| Performance impact on page load                        | Check runs after `DOMContentLoaded` and main render. Storage read is async and non-blocking. Dialog DOM only created if needed          |
+
+## Acceptance criteria
+
+- [ ] Dialog appears automatically on first load after an upgrade (once per version)
+- [ ] Dialog does not appear on subsequent loads for the same version
+- [ ] "What's New" button in settings menu opens the dialog at any time
+- [ ] v1.5.0 content is accurate and complete (all 8 highlights listed)
+- [ ] Previous version sections are collapsible (accordion style)
+- [ ] Visual style matches existing modal patterns (overlay, surface, typography)
+- [ ] Close button (×) and "Got it" button both dismiss and mark as seen
+- [ ] Dialog does not appear if storage read fails (fail closed)
+- [ ] No performance regression — dialog logic runs after main render
+- [ ] No FOUC or layout shift from dialog appearance
+- [ ] Works correctly on fresh install (no previous version → show current)
+- [ ] All quality gates pass
+
+## Test plan
+
+- **Manual:** Fresh install → dialog should appear with v1.5.0 content
+- **Manual:** Reload → dialog should NOT appear again
+- **Manual:** Settings → "What's New" button → dialog opens with all versions
+- **Manual:** Clear `msom:whatsNewLastSeen` from storage → dialog reappears on next load
+- **Manual:** Visual inspection — overlay, panel, typography, accordion all match existing style
+- **Unit tests (if applicable):** Version comparison logic, content data structure validation
+
+## Rollout / migration plan
+
+- Ships as a single PR to `main`
+- First activation: when users receive the v1.5.0 → v1.6.0 update (or whatever the next version is), the dialog will show automatically
+- For v1.5.0 users on fresh install: dialog shows immediately since there's no `lastSeen` value
+- No data migration needed — the feature is purely additive
+
+## Progress log
+
+- 2026-03-15: Plan created. Key decisions: JS object for content (not JSON), `chrome.storage.local` for tracking (not sync), reuse bookmark picker modal patterns.
+
+## Decision log
+
+- 2026-03-15: Chose hardcoded JS object over JSON manifest — simpler, no async fetch, aligns with existing patterns.
+- 2026-03-15: Chose `chrome.storage.local` over `chrome.storage.sync` — this is per-device UI state, not user config; avoids sync quota consumption.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,7 @@ export default [
                 V2_CHUNK_PREFIX: "readonly",
                 V2_TMP_META_KEY: "readonly",
                 V2_TMP_CHUNK_PREFIX: "readonly",
+                WHATS_NEW_LAST_SEEN_KEY: "readonly",
                 fallbackConfig: "readonly",
                 // utils.js
                 hashString: "readonly",
@@ -192,6 +193,14 @@ export default [
                 setAuraPalette: "readonly",
                 sampleDominantColor: "readonly",
                 collectFaviconSources: "readonly",
+                // whats-new-content.js
+                WHATS_NEW_RELEASES: "readonly",
+                // whats-new.js
+                checkWhatsNew: "readonly",
+                openWhatsNew: "readonly",
+                getManifestVersion: "readonly",
+                showWhatsNewDialog: "readonly",
+                dismissWhatsNew: "readonly",
                 // init.js globals (mutable shared state, will be extracted in phase 7)
                 activeConfig: "writable",
                 faviconCache: "writable",
@@ -232,6 +241,8 @@ export default [
             "js/config.js",
             "js/render.js",
             "js/customize.js",
+            "js/whats-new-content.js",
+            "js/whats-new.js",
             "js/init.js"
         ],
         rules: {

--- a/index.html
+++ b/index.html
@@ -339,6 +339,8 @@
         <script src="js/config.js"></script>
         <script src="js/render.js"></script>
         <script src="js/customize.js"></script>
+        <script src="js/whats-new-content.js"></script>
+        <script src="js/whats-new.js"></script>
         <script src="js/init.js"></script>
     </body>
 </html>

--- a/js/constants.js
+++ b/js/constants.js
@@ -24,6 +24,7 @@ const V2_META_KEY = "msom:cfg:v2:meta";
 const V2_CHUNK_PREFIX = "msom:cfg:v2:chunk:";
 const V2_TMP_META_KEY = "msom:cfg:v2:tmp:meta";
 const V2_TMP_CHUNK_PREFIX = "msom:cfg:v2:tmp:chunk:";
+const WHATS_NEW_LAST_SEEN_KEY = "msom:whatsNewLastSeen";
 
 const fallbackConfig = {
     branding: {

--- a/js/init.js
+++ b/js/init.js
@@ -44,6 +44,9 @@ async function init() {
 
     // Show extension name and version from manifest (indicates prod vs QA build).
     renderVersionLabel();
+
+    // Show "What's New" dialog if the user hasn't seen this version yet.
+    checkWhatsNew();
 }
 
 // Reads manifest.json and populates the version label in the settings footer.
@@ -53,7 +56,14 @@ async function renderVersionLabel() {
         const manifest = await res.json();
         const label = document.getElementById("version-label");
         if (label && manifest.name && manifest.version) {
-            label.textContent = `${manifest.name} v${manifest.version}`;
+            label.textContent = `${manifest.name} v${manifest.version} `;
+
+            const whatsNewLink = document.createElement("button");
+            whatsNewLink.className = "whats-new-btn";
+            whatsNewLink.type = "button";
+            whatsNewLink.textContent = "(See what's new)";
+            whatsNewLink.addEventListener("click", openWhatsNew);
+            label.appendChild(whatsNewLink);
         }
     } catch (error) {
         console.error("Failed to load manifest for version label", error);

--- a/js/whats-new-content.js
+++ b/js/whats-new-content.js
@@ -1,0 +1,44 @@
+// Release highlights shown in the "What's New" dialog.
+// Prepend new entries to the array when shipping a new version.
+
+const WHATS_NEW_RELEASES = [
+    {
+        version: "1.5.0",
+        date: "2026-03-15",
+        highlights: [
+            {
+                title: "Section hiding",
+                description:
+                    "Hide sections you don't need right from the main page — unhide them later and they'll snap back to their original position."
+            },
+            {
+                title: "Chromium bookmark import",
+                description:
+                    "Import your browser bookmarks with a folder picker, live quota feedback, and automatic duplicate detection."
+            },
+            {
+                title: "Open all links per section",
+                description: 'New "Open all" button on each section to launch every link in one click.'
+            },
+            {
+                title: "Scroll-to-link highlight",
+                description:
+                    "When you move a link between sections, the page scrolls to it and highlights it so you never lose track."
+            },
+            {
+                title: "Unsaved changes indicator",
+                description: "The Save button lights up when you have unsaved changes — no more guessing."
+            },
+            {
+                title: "Auto-save on exit",
+                description: "Leaving rearrange mode automatically saves your layout changes."
+            },
+            {
+                title: "Version label",
+                description:
+                    "The extension version now appears in the settings footer so you always know what you're running."
+            }
+        ],
+        footer: "I'll update this with each version update. Have a great day! - Dean"
+    }
+];

--- a/js/whats-new.js
+++ b/js/whats-new.js
@@ -1,0 +1,173 @@
+// "What's New" dialog — shows release highlights after an upgrade.
+// Depends on: constants.js, storage.js, whats-new-content.js
+
+// Checks whether the user has seen the current version's highlights.
+// If not, shows the What's New dialog automatically after page load.
+async function checkWhatsNew() {
+    try {
+        const version = await getManifestVersion();
+        if (!version) return;
+
+        const stored = await storageLocal.get(WHATS_NEW_LAST_SEEN_KEY);
+        const lastSeen = stored[WHATS_NEW_LAST_SEEN_KEY];
+
+        if (lastSeen !== version) {
+            showWhatsNewDialog(version);
+        }
+    } catch (error) {
+        // Fail closed — don't annoy the user if storage is unavailable.
+        console.error("What's New check failed", error);
+    }
+}
+
+// Reads the extension version from manifest.json.
+async function getManifestVersion() {
+    try {
+        const res = await fetch("manifest.json");
+        const manifest = await res.json();
+        return manifest.version || null;
+    } catch (error) {
+        console.error("Failed to read manifest for What's New", error);
+        return null;
+    }
+}
+
+// Builds and displays the What's New modal dialog.
+function showWhatsNewDialog(currentVersion) {
+    // Don't stack if another overlay (bookmark picker, etc.) is already open.
+    if (document.querySelector(".whats-new-overlay")) return;
+
+    const overlay = document.createElement("div");
+    overlay.className = "whats-new-overlay";
+
+    const dialog = document.createElement("div");
+    dialog.className = "whats-new-dialog";
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-label", "Mothership Status Update");
+
+    // Header
+    const header = document.createElement("div");
+    header.className = "whats-new-header";
+
+    const title = document.createElement("h3");
+    title.textContent = "Mothership Status Update";
+
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "whats-new-close";
+    closeBtn.type = "button";
+    closeBtn.setAttribute("aria-label", "Close");
+    closeBtn.textContent = "\u00d7";
+    closeBtn.addEventListener("click", () => dismissWhatsNew(overlay, currentVersion));
+
+    header.appendChild(title);
+    header.appendChild(closeBtn);
+
+    // Body — scrollable list of releases
+    const body = document.createElement("div");
+    body.className = "whats-new-body";
+
+    for (let i = 0; i < WHATS_NEW_RELEASES.length; i++) {
+        const release = WHATS_NEW_RELEASES[i];
+        const isCurrentRelease = i === 0;
+
+        const section = document.createElement("div");
+        section.className = "whats-new-release";
+
+        const versionHeader = document.createElement("button");
+        versionHeader.type = "button";
+        versionHeader.className = "whats-new-version";
+        if (isCurrentRelease) versionHeader.classList.add("current");
+        versionHeader.innerHTML = `<span>v${release.version} &mdash; ${release.date}</span><span class="whats-new-chevron">${isCurrentRelease ? "\u25B2" : "\u25BC"}</span>`;
+
+        const items = document.createElement("div");
+        items.className = "whats-new-items";
+        if (!isCurrentRelease) items.classList.add("collapsed");
+
+        for (const highlight of release.highlights) {
+            const item = document.createElement("div");
+            item.className = "whats-new-item";
+
+            const itemTitle = document.createElement("strong");
+            itemTitle.textContent = highlight.title;
+
+            const itemDesc = document.createElement("span");
+            itemDesc.textContent = ` \u2014 ${highlight.description}`;
+
+            item.appendChild(itemTitle);
+            item.appendChild(itemDesc);
+            items.appendChild(item);
+        }
+
+        // Accordion toggle for non-current versions
+        versionHeader.addEventListener("click", () => {
+            const isCollapsed = items.classList.toggle("collapsed");
+            versionHeader.querySelector(".whats-new-chevron").textContent = isCollapsed ? "\u25BC" : "\u25B2";
+        });
+
+        // Optional per-release footer note
+        if (release.footer) {
+            const note = document.createElement("p");
+            note.className = "whats-new-release-note";
+            note.textContent = release.footer;
+            items.appendChild(note);
+        }
+
+        section.appendChild(versionHeader);
+        section.appendChild(items);
+        body.appendChild(section);
+    }
+
+    // Footer — feedback line + dismiss button
+    const footer = document.createElement("div");
+    footer.className = "whats-new-footer";
+
+    const feedback = document.createElement("p");
+    feedback.className = "whats-new-feedback";
+    feedback.textContent = "Questions? Feedback? Comments? Reach out to Dean!";
+
+    const gotItBtn = document.createElement("button");
+    gotItBtn.type = "button";
+    gotItBtn.className = "whats-new-got-it";
+    gotItBtn.textContent = "Got it";
+    gotItBtn.addEventListener("click", () => dismissWhatsNew(overlay, currentVersion));
+
+    footer.appendChild(feedback);
+    footer.appendChild(gotItBtn);
+
+    dialog.appendChild(header);
+    dialog.appendChild(body);
+    dialog.appendChild(footer);
+    overlay.appendChild(dialog);
+
+    // Close on overlay click (outside the dialog)
+    overlay.addEventListener("click", (e) => {
+        if (e.target === overlay) dismissWhatsNew(overlay, currentVersion);
+    });
+
+    // Close on Escape key
+    const escHandler = (e) => {
+        if (e.key === "Escape") {
+            dismissWhatsNew(overlay, currentVersion);
+            document.removeEventListener("keydown", escHandler);
+        }
+    };
+    document.addEventListener("keydown", escHandler);
+
+    document.body.appendChild(overlay);
+}
+
+// Removes the dialog and records the version as seen.
+async function dismissWhatsNew(overlay, version) {
+    overlay.remove();
+    try {
+        await storageLocal.set({ [WHATS_NEW_LAST_SEEN_KEY]: version });
+    } catch (error) {
+        console.error("Failed to save What's New last-seen version", error);
+    }
+}
+
+// Opens the What's New dialog on demand (e.g., from settings menu).
+async function openWhatsNew() {
+    const version = await getManifestVersion();
+    showWhatsNewDialog(version || "unknown");
+}

--- a/tests/helpers/load-script.js
+++ b/tests/helpers/load-script.js
@@ -9,7 +9,17 @@ import { createDocumentMock } from "./dom-mock.js";
 
 // Load module files in dependency order (concatenated for VM sandbox)
 const jsDir = resolve(import.meta.dirname, "../../js");
-const moduleFiles = ["constants.js", "utils.js", "storage.js", "config.js", "render.js", "customize.js", "init.js"];
+const moduleFiles = [
+    "constants.js",
+    "utils.js",
+    "storage.js",
+    "config.js",
+    "render.js",
+    "customize.js",
+    "whats-new-content.js",
+    "whats-new.js",
+    "init.js"
+];
 const scriptSource = moduleFiles.map((f) => readFileSync(resolve(jsDir, f), "utf-8")).join("\n");
 
 export function loadScript(options = {}) {


### PR DESCRIPTION
Add "Mothership Status Update" dialog for post-upgrade release highlights

One-time modal shows v1.5.0 highlights after upgrade, tracked via chrome.storage.local so it only fires once per version per device. Re-openable from a "(See what's new)" link in the settings footer. Accordion layout supports multiple versions for future releases.