### PR TITLE
Fix E2E tests — dismiss What's New overlay before interactions

### DIFF
--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -28,6 +28,13 @@ async function launchExtension() {
         timeout: 10000
     });
 
+    // Dismiss the "What's New" dialog if it appeared (shows on fresh installs).
+    const overlay = page.locator(".whats-new-overlay");
+    if (await overlay.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await page.locator(".whats-new-got-it").click();
+        await overlay.waitFor({ state: "detached", timeout: 2000 });
+    }
+
     return { context, page };
 }
 


### PR DESCRIPTION
The What's New dialog appears on fresh extension loads (no lastSeen in storage), which blocks Playwright clicks on elements behind the overlay. Dismiss it in launchExtension() before returning to tests.